### PR TITLE
remove unnecessary calls to schedule a redraw

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,12 @@ function main(initialState, view, opts) {
     var create = opts.create || vdomCreate
     var diff = opts.diff || vdomDiff
     var patch = opts.patch || vdomPatch
-    var looping = true
+    var redrawScheduled = false
 
     var tree = view(currentState)
     var target = create(tree, opts)
 
     currentState = null
-
-    raf(redraw)
 
     return {
         target: target,
@@ -27,8 +25,8 @@ function main(initialState, view, opts) {
     }
 
     function update(state) {
-        if (currentState === null && !looping) {
-            looping = true
+        if (currentState === null && !redrawScheduled) {
+            redrawScheduled = true
             raf(redraw)
         }
 
@@ -36,8 +34,8 @@ function main(initialState, view, opts) {
     }
 
     function redraw() {
+        redrawScheduled = false;
         if (currentState === null) {
-            looping = false
             return
         }
 
@@ -52,7 +50,5 @@ function main(initialState, view, opts) {
 
         tree = newTree
         currentState = null
-
-        raf(redraw)
     }
 }


### PR DESCRIPTION
when the loop is started, the initial state is rendered and so there is no need
to schedule a redraw for that state - a redraw only needs to happen when the
state changes.

when the state changes, `update` should be called and since initially,
`currentState` will be `null` and `redrawScheduled` will be `false`, a redraw
will be scheduled.

if another state change happens before the redraw then `redrawScheduled` will
prevent another redraw from being scheduled.

once `redraw` is called, a redraw is no longer scheduled and we just need to
determine how to update the previous rendering.  if `currentState` is `null`
then there is no update (this logic was existing before this PR but i wonder
if even `null` should be rendered at least once after the transition from
something non-null)

at the end of `redraw` there is no need to schedule another redraw because that
should only be necessary if an update occurs and that shouldn't happen during a
redraw.
