### PR TITLE
allow state mutations during patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,13 +62,14 @@ function main(initialState, view, opts) {
         var newTree = view(currentState)
 
         if (opts.createOnly) {
+            inRenderingTransaction = false
             create(newTree, opts)
         } else {
             var patches = diff(tree, newTree, opts)
+            inRenderingTransaction = false
             target = patch(target, patches, opts)
         }
 
-        inRenderingTransaction = false
         tree = newTree
         currentState = null
     }


### PR DESCRIPTION
this means that things like blur handlers which may fire during the
patch phase can mutate state without causing an error but we can still
detect mutations during render

refs raynos/mercury#72