### PR TITLE
expose current loop state

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ loop.update({
 })
 ```
 
+## var loop = mainLoop(initState, render, opts)
+
+Create a loop object with some initial state, a render function, and some
+options. Your `function render (state) {}` receives the current state as its
+argument and must return a virtual-dom object.
+
+You must supply: `opts.diff`, `opts.patch`, and `opts.create`. These can be
+obtained directly from `require("virtual-dom")`.
+
+Optionally supply an `opts.target` and `opts.initialTree`.
+
+## loop.target
+
+The main-loop root DOM element. Insert this element to the page.
+
+## loop.update(newState)
+
+Update the page state, automatically re-rendering the page as necessary.
+
 ## Installation
 
 `npm install main-loop`

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The main-loop root DOM element. Insert this element to the page.
 
 Update the page state, automatically re-rendering the page as necessary.
 
+## loop.state
+
+Read the current main-loop state. To modify the loop state, use `loop.update()`.
+
 ## Installation
 
 `npm install main-loop`

--- a/index.js
+++ b/index.js
@@ -31,10 +31,12 @@ function main(initialState, view, opts) {
 
     currentState = null
 
-    return {
+    var loop = {
+        state: initialState,
         target: target,
         update: update
     }
+    return loop
 
     function update(state) {
         if (inRenderingTransaction) {
@@ -50,6 +52,7 @@ function main(initialState, view, opts) {
         }
 
         currentState = state
+        loop.state = state
     }
 
     function redraw() {

--- a/test/index.js
+++ b/test/index.js
@@ -68,3 +68,20 @@ test("can set up main loop", function (assert) {
         })
     })
 })
+
+test("loop.state exposed", function (assert) {
+    var loop = mainLoop({ n: 0 }, render, {
+        document: document,
+        create: require("virtual-dom/create-element"),
+        diff: require("virtual-dom/diff"),
+        patch: require("virtual-dom/patch")
+    })
+    assert.equal(loop.state.n, 0)
+    loop.update({ n: 4 })
+    assert.equal(loop.state.n, 4)
+    assert.end()
+ 
+    function render(state) {
+        return h('div', String(state.n))
+    }
+})


### PR DESCRIPTION
This patch exposes the current loop state as `loop.state`. I find myself repeatedly needing to read the loop state in many circumstances, so I usually create a `state` variable, but then I need to keep the loop state in sync with that variable and I need to pass around both objects all over the place. One recent example is to get browserify-hmr working well with main-loop, I need to trigger a loop update with the current state unchanged. With this patch `loop.update(loop.state)` will do the trick.

One caveat is that people might try writing to this value instead of calling `loop.update()` but I added a note to the docs to say not to do that.

If nothing else, you can cherry-pick 0b534b5 to get more API docs without the other state-exposing changes.