### PR TITLE
Pass Through High Resolution Time from raf

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var raf = require("raf")
+var now = require('performance-now')
 var TypedError = require("error/typed")
 
 var InvalidUpdateInRender = TypedError({
@@ -26,7 +27,7 @@ function main(initialState, view, opts) {
     var patch = opts.patch
     var redrawScheduled = false
 
-    var tree = opts.initialTree || view(currentState)
+    var tree = opts.initialTree || view(currentState, now());
     var target = opts.target || create(tree, opts)
     var inRenderingTransaction = false
 
@@ -56,14 +57,14 @@ function main(initialState, view, opts) {
         loop.state = state
     }
 
-    function redraw() {
+    function redraw(time) {
         redrawScheduled = false
         if (currentState === null) {
             return
         }
 
         inRenderingTransaction = true
-        var newTree = view(currentState)
+        var newTree = view(currentState, time)
 
         if (opts.createOnly) {
             inRenderingTransaction = false

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var raf = require("raf")
-var now = require('performance-now')
 var TypedError = require("error/typed")
 
 var InvalidUpdateInRender = TypedError({
@@ -27,7 +26,7 @@ function main(initialState, view, opts) {
     var patch = opts.patch
     var redrawScheduled = false
 
-    var tree = opts.initialTree || view(currentState, now());
+    var tree = opts.initialTree || view(currentState, 0);
     var target = opts.target || create(tree, opts)
     var inRenderingTransaction = false
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-loop",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A rendering loop for diffable UIs",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "error": "^4.1.1",
-    "raf": "^2.0.1",
-    "performance-now": "^0.1.4"
+    "raf": "^2.0.1"
   },
   "devDependencies": {
     "global": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "error": "^4.1.1",
-    "raf": "^2.0.1"
+    "raf": "^2.0.1",
+    "performance-now": "^0.1.4"
   },
   "devDependencies": {
     "global": "^3.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -80,8 +80,40 @@ test("loop.state exposed", function (assert) {
     loop.update({ n: 4 })
     assert.equal(loop.state.n, 4)
     assert.end()
- 
+
     function render(state) {
         return h('div', String(state.n))
     }
 })
+
+test("render called with monotonically increasing times", function(assert){
+    assert.plan(2)
+
+    var times = []
+    var loop = mainLoop({ n: 0 }, render, {
+        document: document,
+        create: require("virtual-dom/create-element"),
+        diff: require("virtual-dom/diff"),
+        patch: require("virtual-dom/patch")
+    })
+
+
+    function render(state, time) {
+        times.push(time);
+        return h('div', String(state.n))
+    }
+
+
+    raf(function () {
+
+        loop.update({ n: 1})
+
+        raf(function () {
+            loop.update({ n: 2})
+
+            assert.equal(times.length, 2)
+            assert.ok(times[0] < times[1], "should be increasing")
+            assert.end()
+        })
+    })
+});


### PR DESCRIPTION
This adds an argument to the render callback, containing the high resolution time from the underlying call to `requestAnimationFrame`.

This allows for complex animations not supported by CSS 3 transitions, without stacking calls to raf.

The [`performance-now`](https://www.npmjs.com/package/performance-now) module is included to provide a valid time when creating the initial view state. This is the same package used by `raf`.